### PR TITLE
Fix deadline validation logic in add_task method

### DIFF
--- a/application.py
+++ b/application.py
@@ -64,7 +64,7 @@ class ToDoListApp:
             return
 
         # Validate deadline
-        if deadline:
+        if deadline and deadline != "YYYY-MM-DD":
             try:
                 deadline_date = datetime.strptime(deadline, "%Y-%m-%d").date()
             except ValueError:
@@ -81,6 +81,7 @@ class ToDoListApp:
         self.task_entry.delete(0, tk.END)
         self.deadline_entry.delete(0, tk.END)
         self.deadline_entry.insert(0, "YYYY-MM-DD")
+
 
     def mark_task_done(self):
         """Mark the selected task as done."""


### PR DESCRIPTION
This pull request fixes a bug in the add_task method where:
- The deadline field was not properly validated, allowing invalid or placeholder values to be used.
- Added a validation step to ensure that only valid date formats (YYYY-MM-DD) are accepted, and placeholders like "YYYY-MM-DD" are ignored.
- If no deadline is provided, the deadline defaults to None.
